### PR TITLE
fix: same name for 2d data as 3d data

### DIFF
--- a/autonomy/include/aurora/lunatic.h
+++ b/autonomy/include/aurora/lunatic.h
@@ -169,7 +169,7 @@ project depth camera obstacles into field coordinates:
     Read by the obstacle detection subsystem
 Coordinate system: absolute field coordinates
 */
-#define MAKE_exchange_obstacle_view()   aurora::data_exchange<aurora::robot_coord3D> exchange_plan_target("plan_target.loc2D")
+#define MAKE_exchange_obstacle_view()   aurora::data_exchange<aurora::robot_coord3D> exchange_plan_target("plan_target.loc3D")
 
 
 


### PR DESCRIPTION
Is this intended? It seems like the data_exchange for robot_coord3D should be writting to plan_target.loc3D? if not data will be overwritten by backend when writing 2d cords for driving somewhere new? Unsure just noticed it..